### PR TITLE
Fix Beidou C6 resistance debuff

### DIFF
--- a/internal/characters/beidou/beidou.go
+++ b/internal/characters/beidou/beidou.go
@@ -273,7 +273,7 @@ func (c *char) Burst(p map[string]int) int {
 			t.AddResMod("beidouc6", core.ResistMod{
 				Duration: 900, //10 seconds
 				Ele:      core.Electro,
-				Value:    -0.1,
+				Value:    -0.15,
 			})
 		}
 	}


### PR DESCRIPTION
Beidou C6 resisitance debuff is -15%; original code has it set to -10%.