### PR TITLE
fix noelle shield

### DIFF
--- a/internal/characters/noelle/noelle.go
+++ b/internal/characters/noelle/noelle.go
@@ -183,6 +183,7 @@ func (c *char) newShield(base float64, t core.ShieldType, dur int) *noelleShield
 	n.Tmpl.ShieldType = t
 	n.Tmpl.HP = base
 	n.Tmpl.Expires = c.Core.F + dur
+	n.c = c
 	return n
 }
 


### PR DESCRIPTION
fix 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x655598]

goroutine 22 [running]:
github.com/genshinsim/gsim/internal/characters/noelle.(*noelleShield).OnExpire(0xc000190200)
    C:/HOME/Projects/gsim/internal/characters/noelle/noelle.go:166 +0x18
github.com/genshinsim/gsim/pkg/core.(*ShieldCtrl).Tick(0xc00019c140)
    C:/HOME/Projects/gsim/pkg/core/shield.go:118 +0x12b
github.com/genshinsim/gsim/pkg/core.(*Core).Tick(0xc0001ac000)
    C:/HOME/Projects/gsim/pkg/core/core.go:269 +0x56
github.com/genshinsim/gsim.(*Simulation).AdvanceFrame(0xc0001aa000)
    C:/HOME/Projects/gsim/run.go:67 +0x3a
github.com/genshinsim/gsim.(*Simulation).Run(0xc0001aa000)
    C:/HOME/Projects/gsim/run.go:40 +0x396
github.com/genshinsim/gsim.worker({0xc000132400, 0x217}, {0x1, 0xbb8, 0x18, 0x19, 0x0, {0xc4f780, 0x0, 0x0}}, ...)
    C:/HOME/Projects/gsim/worker.go:370 +0x378
created by github.com/genshinsim/gsim.Run
    C:/HOME/Projects/gsim/worker.go:117 +0x3ac
```