### PR TITLE
Fix Lion's Roar passive to check for correct elements

### DIFF
--- a/internal/weapons/sword/lion/lion.go
+++ b/internal/weapons/sword/lion/lion.go
@@ -26,7 +26,7 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) {
 			return false
 		}
 
-		if t.AuraContains(core.Electro, core.Hydro) {
+		if t.AuraContains(core.Electro, core.Pyro) {
 			ds.Stats[core.DmgP] += dmg
 			c.Log.Debugw("lion's roar", "frame", c.F, "event", core.LogWeaponEvent, "char", char.CharIndex(), "final dmg%", ds.Stats[core.DmgP])
 		}


### PR DESCRIPTION
Lion's roar was checking for Electro/Hydro and not Electro/Pyro.