### PR TITLE
Initial logging changes - Snapshot optimizations and add Status logs

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -35,6 +35,7 @@ type Core struct {
 	Flags Flags // global flags
 	Rand  *rand.Rand
 	Log   *zap.SugaredLogger
+	LogLevelDebug bool
 
 	//core data
 	Stam   float64
@@ -97,6 +98,11 @@ func New(cfg ...func(*Core) error) (*Core, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	c.LogLevelDebug = false
+	if c.Log.Desugar().Check(zap.DebugLevel, "debug") != nil {
+		c.LogLevelDebug = true
 	}
 
 	if c.Rand == nil {

--- a/pkg/core/status.go
+++ b/pkg/core/status.go
@@ -31,6 +31,12 @@ func (s *StatusCtrl) Duration(key string) int {
 
 func (s *StatusCtrl) AddStatus(key string, dur int) {
 	s.status[key] = s.core.F + dur
+	s.core.Log.Debugw(
+		"Added Status " + key,
+		"event", LogStatusEvent,
+		"frame", s.core.F,
+		"expiration", s.core.F + dur,
+	)
 }
 
 func (s *StatusCtrl) DeleteStatus(key string) {


### PR DESCRIPTION
For the snapshot optimizations, it looks like the snapshot logs were being generated on every run, but I think it's only really needed on the debug run, so I added some code to prevent it from logging if it's not at the debug run, which doesn't seem to affect anything and improves run times by 1/3 on my machine on 3000 iterations (~3 seconds -> ~2 seconds). I'm not sure if there is anywhere else in the code where we want to do something similar.

I also changed the snapshot character mod logs to just name the stat and value instead of having this big array since it was really hard to debug issues while trying to parse it. With the log changes it incurs basically no performance impact.

I also noticed that there's a "LogStatusEvent", but it wasn't being used. I assume that's for character statuses and durations, so I added in log entries for it.