### PR TITLE
Adjust snapshot timings - Core, Raiden, XQ, Bennett

### DIFF
--- a/internal/characters/bennett/bennett.go
+++ b/internal/characters/bennett/bennett.go
@@ -91,19 +91,22 @@ func (c *char) ActionFrames(a core.ActionType, p map[string]int) (int, int) {
 func (c *char) Attack(p map[string]int) (int, int) {
 
 	f, a := c.ActionFrames(core.ActionAttack, p)
-	d := c.Snapshot(
-		fmt.Sprintf("Normal %v", c.NormalCounter),
-		core.AttackTagNormal,
-		core.ICDTagNormalAttack,
-		core.ICDGroupDefault,
-		core.StrikeTypeSlash,
-		core.Physical,
-		25,
-		attack[c.NormalCounter][c.TalentLvlAttack()],
-	)
-	d.Targets = core.TargetAll
 
-	c.QueueDmg(&d, f-1)
+	c.QueueDmgDynamic(func() *core.Snapshot {
+		d := c.Snapshot(
+			fmt.Sprintf("Normal %v", c.NormalCounter),
+			core.AttackTagNormal,
+			core.ICDTagNormalAttack,
+			core.ICDGroupDefault,
+			core.StrikeTypeSlash,
+			core.Physical,
+			25,
+			attack[c.NormalCounter][c.TalentLvlAttack()],
+		)
+		d.Targets = core.TargetAll
+
+		return &d
+	}, f-1)
 	c.AdvanceNormalIndex()
 
 	return f, a
@@ -139,18 +142,21 @@ func (c *char) Skill(p map[string]int) (int, int) {
 
 func (c *char) skillPress() {
 
-	d := c.Snapshot(
-		"Passion Overload (Press)",
-		core.AttackTagElementalArt,
-		core.ICDTagNone,
-		core.ICDGroupDefault,
-		core.StrikeTypeSlash,
-		core.Pyro,
-		50,
-		skill[c.TalentLvlSkill()],
-	)
-	d.Targets = core.TargetAll
-	c.QueueDmg(&d, 15)
+	c.QueueDmgDynamic(func() *core.Snapshot {
+		d := c.Snapshot(
+			"Passion Overload (Press)",
+			core.AttackTagElementalArt,
+			core.ICDTagNone,
+			core.ICDGroupDefault,
+			core.StrikeTypeSlash,
+			core.Pyro,
+			50,
+			skill[c.TalentLvlSkill()],
+		)
+		d.Targets = core.TargetAll
+
+		return &d
+	}, 15)
 
 	//25 % chance of 3 orbs
 	count := 2
@@ -164,21 +170,22 @@ func (c *char) skillHoldShort() {
 
 	delay := []int{89, 115}
 
-	d := c.Snapshot(
-		"Passion Overload (Hold)",
-		core.AttackTagElementalArt,
-		core.ICDTagNone,
-		core.ICDGroupDefault,
-		core.StrikeTypeSlash,
-		core.Pyro,
-		25,
-		0,
-	)
-	d.Targets = core.TargetAll
 	for i, v := range skill1 {
-		x := d.Clone()
-		x.Mult = v[c.TalentLvlSkill()]
-		c.QueueDmg(&x, delay[i])
+		c.QueueDmgDynamic(func() *core.Snapshot {
+			d := c.Snapshot(
+				"Passion Overload (Hold)",
+				core.AttackTagElementalArt,
+				core.ICDTagNone,
+				core.ICDGroupDefault,
+				core.StrikeTypeSlash,
+				core.Pyro,
+				25,
+				v[c.TalentLvlSkill()],
+			)
+			d.Targets = core.TargetAll
+
+			return &d
+		}, delay[i])
 	}
 
 	//25 % chance of 3 orbs
@@ -194,35 +201,39 @@ func (c *char) skillHoldLong() {
 
 	delay := []int{136, 154}
 
-	d := c.Snapshot(
-		"Passion Overload (Hold)",
-		core.AttackTagElementalArt,
-		core.ICDTagNone,
-		core.ICDGroupDefault,
-		core.StrikeTypeSlash,
-		core.Pyro,
-		25,
-		0,
-	)
-	d.Targets = core.TargetAll
 	for i, v := range skill2 {
-		x := d.Clone()
-		x.Mult = v[c.TalentLvlSkill()]
-		c.QueueDmg(&x, delay[i])
+		c.QueueDmgDynamic(func() *core.Snapshot {
+			d := c.Snapshot(
+				"Passion Overload (Hold)",
+				core.AttackTagElementalArt,
+				core.ICDTagNone,
+				core.ICDGroupDefault,
+				core.StrikeTypeSlash,
+				core.Pyro,
+				25,
+				v[c.TalentLvlSkill()],
+			)
+			d.Targets = core.TargetAll
+
+			return &d
+		}, delay[i])
 	}
 
-	d2 := c.Snapshot(
-		"Passion Overload (Explode)",
-		core.AttackTagElementalArt,
-		core.ICDTagNone,
-		core.ICDGroupDefault,
-		core.StrikeTypeDefault,
-		core.Pyro,
-		25,
-		explosion[c.TalentLvlSkill()],
-	)
-	d2.Targets = core.TargetAll
-	c.QueueDmg(&d2, 198)
+	c.QueueDmgDynamic(func() *core.Snapshot {
+		d2 := c.Snapshot(
+			"Passion Overload (Explode)",
+			core.AttackTagElementalArt,
+			core.ICDTagNone,
+			core.ICDGroupDefault,
+			core.StrikeTypeDefault,
+			core.Pyro,
+			25,
+			explosion[c.TalentLvlSkill()],
+		)
+		d2.Targets = core.TargetAll
+
+		return &d2
+	}, 198)
 
 	//25 % chance of 3 orbs
 	count := 2

--- a/internal/characters/raiden/abil.go
+++ b/internal/characters/raiden/abil.go
@@ -27,18 +27,20 @@ func (c *char) Attack(p map[string]int) (int, int) {
 	}
 
 	for i, mult := range attack[c.NormalCounter] {
-		d := c.Snapshot(
-			//fmt.Sprintf("Normal %v", c.NormalCounter),
-			"Normal",
-			core.AttackTagNormal,
-			core.ICDTagNormalAttack,
-			core.ICDGroupDefault,
-			core.StrikeTypeSlash,
-			core.Physical,
-			25,
-			mult[c.TalentLvlAttack()],
-		)
-		c.QueueDmg(&d, f-polearmDelayOffset[c.NormalCounter][i])
+		c.QueueDmgDynamic(func() *core.Snapshot {
+			d := c.Snapshot(
+				//fmt.Sprintf("Normal %v", c.NormalCounter),
+				"Normal",
+				core.AttackTagNormal,
+				core.ICDTagNormalAttack,
+				core.ICDGroupDefault,
+				core.StrikeTypeSlash,
+				core.Physical,
+				25,
+				mult[c.TalentLvlAttack()],
+			)
+			return &d
+		}, f-polearmDelayOffset[c.NormalCounter][i])
 	}
 
 	c.AdvanceNormalIndex()
@@ -57,23 +59,24 @@ var swordDelayOffset = [][]int{
 func (c *char) swordAttack(f int, a int) (int, int) {
 
 	for i, mult := range attackB[c.NormalCounter] {
-		d := c.Snapshot(
-			// fmt.Sprintf("Musou Isshin %v", c.NormalCounter),
-			"Musou Isshin",
-			core.AttackTagElementalBurst,
-			core.ICDTagNormalAttack,
-			core.ICDGroupDefault,
-			core.StrikeTypeSlash,
-			core.Electro,
-			25,
-			mult[c.TalentLvlBurst()],
-		)
-		//adds to talent %
-		d.Mult += resolveBonus[c.TalentLvlBurst()] * c.stacksConsumed
-		if c.Base.Cons >= 2 {
-			d.DefAdj = -0.6
-		}
+		// Sword hits are dynamic - group snapshots with damage proc
 		c.AddTask(func() {
+			d := c.Snapshot(
+				// fmt.Sprintf("Musou Isshin %v", c.NormalCounter),
+				"Musou Isshin",
+				core.AttackTagElementalBurst,
+				core.ICDTagNormalAttack,
+				core.ICDGroupDefault,
+				core.StrikeTypeSlash,
+				core.Electro,
+				25,
+				mult[c.TalentLvlBurst()],
+			)
+			//adds to talent %
+			d.Mult += resolveBonus[c.TalentLvlBurst()] * c.stacksConsumed
+			if c.Base.Cons >= 2 {
+				d.DefAdj = -0.6
+			}
 			c.Core.Combat.ApplyDamage(&d)
 			//restore energy
 			if c.Core.F > c.restoreICD && c.restoreCount < 5 {
@@ -103,18 +106,19 @@ func (c *char) ChargeAttack(p map[string]int) (int, int) {
 
 		f, a := c.ActionFrames(core.ActionCharge, p)
 
-		d := c.Snapshot(
-			"Charge 1",
-			core.AttackTagNormal,
-			core.ICDTagNormalAttack,
-			core.ICDGroupDefault,
-			core.StrikeTypeSlash,
-			core.Physical,
-			25,
-			charge[c.TalentLvlAttack()],
-		)
-
-		c.QueueDmg(&d, f-31) //TODO: damage frame
+		c.QueueDmgDynamic(func() *core.Snapshot {
+			d := c.Snapshot(
+				"Charge 1",
+				core.AttackTagNormal,
+				core.ICDTagNormalAttack,
+				core.ICDGroupDefault,
+				core.StrikeTypeSlash,
+				core.Physical,
+				25,
+				charge[c.TalentLvlAttack()],
+			)
+			return &d
+		}, f-31) //TODO: damage frame
 
 		return f, a
 	}
@@ -128,23 +132,23 @@ func (c *char) swordCharge(p map[string]int) (int, int) {
 	f, a := c.ActionFrames(core.ActionCharge, p)
 
 	for _, mult := range chargeSword {
-		d := c.Snapshot(
-			// fmt.Sprintf("Musou Isshin %v", c.NormalCounter),
-			"Musou Isshin",
-			core.AttackTagElementalBurst,
-			core.ICDTagNormalAttack,
-			core.ICDGroupDefault,
-			core.StrikeTypeSlash,
-			core.Electro,
-			25,
-			mult[c.TalentLvlBurst()],
-		)
-		//adds to talent %
-		d.Mult += resolveBonus[c.TalentLvlBurst()] * c.stacksConsumed
-		if c.Base.Cons >= 2 {
-			d.DefAdj = -0.6
-		}
 		c.AddTask(func() {
+			d := c.Snapshot(
+				// fmt.Sprintf("Musou Isshin %v", c.NormalCounter),
+				"Musou Isshin",
+				core.AttackTagElementalBurst,
+				core.ICDTagNormalAttack,
+				core.ICDGroupDefault,
+				core.StrikeTypeSlash,
+				core.Electro,
+				25,
+				mult[c.TalentLvlBurst()],
+			)
+			//adds to talent %
+			d.Mult += resolveBonus[c.TalentLvlBurst()] * c.stacksConsumed
+			if c.Base.Cons >= 2 {
+				d.DefAdj = -0.6
+			}
 			c.Core.Combat.ApplyDamage(&d)
 			//restore energy
 			if c.Core.F > c.restoreICD && c.restoreCount < 5 {
@@ -173,19 +177,21 @@ Eye of Stormy Judgment
 
 func (c *char) Skill(p map[string]int) (int, int) {
 	f, a := c.ActionFrames(core.ActionSkill, p)
-	d := c.Snapshot(
-		"Eye of Stormy Judgement",
-		core.AttackTagElementalArt,
-		core.ICDTagNone,
-		core.ICDGroupDefault,
-		core.StrikeTypeDefault,
-		core.Electro,
-		25,
-		skill[c.TalentLvlSkill()],
-	)
-	d.Targets = core.TargetAll
 
-	c.QueueDmg(&d, f+19)
+	c.QueueDmgDynamic(func() *core.Snapshot {
+		d := c.Snapshot(
+			"Eye of Stormy Judgement",
+			core.AttackTagElementalArt,
+			core.ICDTagNone,
+			core.ICDGroupDefault,
+			core.StrikeTypeDefault,
+			core.Electro,
+			25,
+			skill[c.TalentLvlSkill()],
+		)
+		d.Targets = core.TargetAll
+		return &d
+	}, f+19)
 
 	//activate eye
 	c.Core.Status.AddStatus("raidenskill", 1500+f)
@@ -222,29 +228,31 @@ func (c *char) eyeOnDamage() {
 		if dmg == 0 {
 			return false
 		}
-		//trigger a strike
-		//does not snapshot, so this is fine
-		d := c.Snapshot(
-			"Eye of Stormy Judgement (Strike)",
-			core.AttackTagElementalArt,
-			core.ICDTagElementalArt,
-			core.ICDGroupDefault,
-			core.StrikeTypeDefault,
-			core.Electro,
-			25,
-			skillTick[c.TalentLvlSkill()],
-		)
-		d.Targets = core.TargetAll
-		if c.Base.Cons >= 2 && c.Core.Status.Duration("raidenburst") > 0 {
-			d.DefAdj = -0.6
-		}
 		if c.Core.Rand.Float64() < 0.5 {
 			c.QueueParticle("raiden", 1, core.Electro, 100)
 		}
 
 		//https://streamable.com/28at4f hit mark 857, eye land 862
 		//electro appears to be applied right away
-		c.QueueDmg(&d, 5)
+		c.QueueDmgDynamic(func() *core.Snapshot {
+			//trigger a strike
+			//does not snapshot, so this is fine
+			d := c.Snapshot(
+				"Eye of Stormy Judgement (Strike)",
+				core.AttackTagElementalArt,
+				core.ICDTagElementalArt,
+				core.ICDGroupDefault,
+				core.StrikeTypeDefault,
+				core.Electro,
+				25,
+				skillTick[c.TalentLvlSkill()],
+			)
+			d.Targets = core.TargetAll
+			if c.Base.Cons >= 2 && c.Core.Status.Duration("raidenburst") > 0 {
+				d.DefAdj = -0.6
+			}
+			return &d
+		}, 5)
 		c.eyeICD = c.Core.F + 54 //0.9 sec icd
 		return false
 	}, "raiden-eye")
@@ -283,28 +291,25 @@ func (c *char) Burst(p map[string]int) (int, int) {
 
 	c.Core.Log.Debugw("resolve stacks", "frame", c.Core.F, "event", core.LogCharacterEvent, "char", c.Index, "stacks", c.stacksConsumed)
 
-	// c.AddTask(func() {
-	d := c.Snapshot(
-		"Musou Shinsetsu",
-		core.AttackTagElementalBurst,
-		core.ICDTagElementalBurst,
-		core.ICDGroupDefault,
-		core.StrikeTypeDefault,
-		core.Electro,
-		50,
-		burstBase[c.TalentLvlBurst()],
-	)
-	d.Targets = core.TargetAll
-	d.Mult += resolveBaseBonus[c.TalentLvlBurst()] * c.stacksConsumed
+	c.QueueDmgDynamic(func() *core.Snapshot {
+		d := c.Snapshot(
+			"Musou Shinsetsu",
+			core.AttackTagElementalBurst,
+			core.ICDTagElementalBurst,
+			core.ICDGroupDefault,
+			core.StrikeTypeDefault,
+			core.Electro,
+			50,
+			burstBase[c.TalentLvlBurst()],
+		)
+		d.Targets = core.TargetAll
+		d.Mult += resolveBaseBonus[c.TalentLvlBurst()] * c.stacksConsumed
 
-	if c.Base.Cons >= 2 {
-		d.DefAdj = -0.6
-	}
-
-	c.QueueDmg(&d, f)
-	// c.Core.Combat.ApplyDamage(&d)
-
-	// }, "raiden-burst", f)
+		if c.Base.Cons >= 2 {
+			d.DefAdj = -0.6
+		}
+		return &d
+	}, f)
 
 	c.SetCD(core.ActionBurst, 18*60) //20s cd
 	c.Energy = 0

--- a/internal/characters/xingqiu/burst.go
+++ b/internal/characters/xingqiu/burst.go
@@ -6,36 +6,37 @@ func (c *char) summonSwordWave() {
 	//trigger swords, only first sword applies hydro
 	for i := 0; i < c.numSwords; i++ {
 		wave := i
-		d := c.Snapshot(
-			"Guhua Sword: Raincutter",
-			core.AttackTagElementalBurst,
-			core.ICDTagElementalBurst,
-			core.ICDGroupDefault,
-			core.StrikeTypePierce,
-			core.Hydro,
-			25,
-			burst[c.TalentLvlBurst()],
-		)
-		d.Targets = 0 //only hit main target
-		d.OnHitCallback = func(t core.Target) {
-			//check energy
-			if c.nextRegen && wave == 0 {
-				c.AddEnergy(3)
-			}
-			//check c2
-			if c.Base.Cons >= 2 {
-				c.AddTask(func() {
-					t.AddResMod("xingqiu-c2", core.ResistMod{
-						Ele:      core.Hydro,
-						Value:    -0.15,
-						Duration: 4 * 60,
-					})
-				}, "xq-sword-debuff", 1)
+		c.QueueDmgDynamic(func() *core.Snapshot {
+			d := c.Snapshot(
+				"Guhua Sword: Raincutter",
+				core.AttackTagElementalBurst,
+				core.ICDTagElementalBurst,
+				core.ICDGroupDefault,
+				core.StrikeTypePierce,
+				core.Hydro,
+				25,
+				burst[c.TalentLvlBurst()],
+			)
+			d.Targets = 0 //only hit main target
+			d.OnHitCallback = func(t core.Target) {
+				//check energy
+				if c.nextRegen && wave == 0 {
+					c.AddEnergy(3)
+				}
+				//check c2
+				if c.Base.Cons >= 2 {
+					c.AddTask(func() {
+						t.AddResMod("xingqiu-c2", core.ResistMod{
+							Ele:      core.Hydro,
+							Value:    -0.15,
+							Duration: 4 * 60,
+						})
+					}, "xq-sword-debuff", 1)
 
+				}
 			}
-		}
-
-		c.QueueDmg(&d, 20)
+			return &d
+		}, 20)
 
 		c.burstCounter++
 	}

--- a/pkg/character/tasks.go
+++ b/pkg/character/tasks.go
@@ -15,3 +15,11 @@ func (t *Tmpl) QueueDmg(ds *core.Snapshot, delay int) {
 		t.Core.Combat.ApplyDamage(ds)
 	}, "dmg", delay)
 }
+
+// Helper/descriptive function to create a snapshot instance and queue up the damage on the same frame.
+// Best used for all abilities that do not snapshot in game (e.g. normal attacks, Hu Tao blood blossoms, etc.)
+func (t *Tmpl) QueueDmgDynamic(generateSnapshot func() *core.Snapshot, delay int) {
+	t.AddTask(func() {
+		t.Core.Combat.ApplyDamage(generateSnapshot())
+	}, "dmg", delay)
+}


### PR DESCRIPTION
This PR starts the process for adjusting snapshot timings (partially fixes #31) and implements the following fixes:

1. Adds a helper function in the core to align the snapshot generation and damage instance
2. Fixes the timings for Raiden, XQ, and Bennett who are all known to have fully dynamic abilities.